### PR TITLE
Filter on status

### DIFF
--- a/browser/src/components/FoiaList.js
+++ b/browser/src/components/FoiaList.js
@@ -4,6 +4,7 @@ const FoiaList = () => {
   const [data, setData] = useState();
   const [error, setError] = useState();
   const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -14,36 +15,55 @@ const FoiaList = () => {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <p>Loading...</p>;
+  if (loading) return <p>Loading…</p>;
   if (error) return <pre>{JSON.stringify(error, null, 2)}</pre>;
+
+  const uniqueStatuses = new Set();
+  data && data.foiaList.forEach(item => uniqueStatuses.add(item.foiaReq.status));
+  const statusOptions = [];
+  uniqueStatuses.forEach(item => statusOptions.push(item));
 
   return data ? (
     <div className="foia-list">
-      {data.foiaList.map(item => (
-        <div key={item.agency.id + item.foiaReq.id + item.jurisdiction.id} className="foia-list__item">
-          <h2><a href={item.foiaReq.absolute_url}>{item.agency.agencyName}</a></h2>
-          <table>
-            <tbody>
-              <tr>
-                <td>Submitted</td>
-                <td><time dateTime={item.foiaReq.datetime_submitted}>{item.foiaReq.datetime_submitted}</time></td>
-              </tr>
-              <tr>
-                <td>Completed</td>
-                <td><time dateTime={item.foiaReq.datetime_done}>{item.foiaReq.datetime_done}</time></td>
-              </tr>
-              <tr>
-                <td>Status</td>
-                <td>{item.foiaReq.status}</td>
-              </tr>
-              <tr>
-                <td>Cost</td>
-                <td>${item.foiaReq.price}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      ))}
+      <div className="foia-list__filters">
+        <p className="foia-list__filters-heading">Refine results</p>
+        <form className="foia-list__filters-form">
+          <label htmlFor="foia-list-statuses">Status</label>
+          <select id="foia-list-statuses" onChange={event => setStatus(event.target.value)}>
+            <option value="" key="none">Select a status</option>
+            {statusOptions.map(status => (
+              <option value={status} key={status}>{status}</option>
+            ))}
+          </select>
+        </form>
+      </div>
+      <div className="foia-list__results">
+        {data.foiaList.map(item => (
+          <div hidden={status && item.foiaReq.status !== status} key={item.agency.id + item.foiaReq.id + item.jurisdiction.id} className="foia-list__item">
+            <h2><a href={item.foiaReq.absolute_url}>{item.agency.agencyName}</a></h2>
+            <table>
+              <tbody>
+                <tr>
+                  <td>Submitted</td>
+                  <td><time dateTime={item.foiaReq.datetime_submitted}>{item.foiaReq.datetime_submitted}</time></td>
+                </tr>
+                <tr>
+                  <td>Completed</td>
+                  <td><time dateTime={item.foiaReq.datetime_done}>{item.foiaReq.datetime_done}</time></td>
+                </tr>
+                <tr>
+                  <td>Status</td>
+                  <td>{item.foiaReq.status}</td>
+                </tr>
+                <tr>
+                  <td>Cost</td>
+                  <td>${item.foiaReq.price}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        ))}
+      </div>
     </div>
   ) : (
     <p>No data.</p>

--- a/browser/src/components/FoiaList.js
+++ b/browser/src/components/FoiaList.js
@@ -18,7 +18,33 @@ const FoiaList = () => {
   if (error) return <pre>{JSON.stringify(error, null, 2)}</pre>;
 
   return data ? (
-    <p>Data length: {data && data.foiaList.length}</p>
+    <div className="foia-list">
+      {data.foiaList.map(item => (
+        <div key={item.agency.id + item.foiaReq.id + item.jurisdiction.id} className="foia-list__item">
+          <h2><a href={item.foiaReq.absolute_url}>{item.agency.agencyName}</a></h2>
+          <table>
+            <tbody>
+              <tr>
+                <td>Submitted</td>
+                <td><time dateTime={item.foiaReq.datetime_submitted}>{item.foiaReq.datetime_submitted}</time></td>
+              </tr>
+              <tr>
+                <td>Completed</td>
+                <td><time dateTime={item.foiaReq.datetime_done}>{item.foiaReq.datetime_done}</time></td>
+              </tr>
+              <tr>
+                <td>Status</td>
+                <td>{item.foiaReq.status}</td>
+              </tr>
+              <tr>
+                <td>Cost</td>
+                <td>${item.foiaReq.price}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
   ) : (
     <p>No data.</p>
   );


### PR DESCRIPTION
## List all content

Render all foia request items fetched from the muckrock API with the key
data visible. This will help show what's actually happening when we add
filters.

## Add naïve status filter

Add some native React filtering for status. Find the possible statuses
by dynamically storing the unique ones. This is a temporary solution,
since we'll eventually want to map them to the more human friendly
versions Beryl (or whomever) comes up with.

The main data filtering is similarly basic - just hide an item via
`[hidden]` if it doesn't match the status.

**TODO**: talk through other filtering options.
