### PR TITLE
Make filtering logic more elegant and less buggy

### DIFF
--- a/browser/src/components/FoiaList.js
+++ b/browser/src/components/FoiaList.js
@@ -2,13 +2,24 @@ import React, { useState } from "react";
 
 const FoiaList = (props) => { const [status, setStatus] = useState();
   const [price, setPrice] = useState();
+  const [turnaround, setTurnaround] = useState();
   const filterData = {};
+  const [filters, setFilters] = useState({});
 
   function applyFilter(item) {
-    let visible = true;
-    if (status && item.foiaReq.status !== status) visible = false;
-    if (price && parseFloat(item.foiaReq.price) !== parseFloat(price)) visible = false;
-    return visible;
+    if (!Object.getOwnPropertyNames(filters).length) return true;
+    let isVisible = [];
+    for (let key in filters) {
+      if (filters[key] === '') {
+        isVisible.push(0);
+      }
+      else {
+        const filter = key === 'price' ? parseFloat(filters[key]) : filters[key];
+        const request = key === 'price' ? parseFloat(item.foiaReq[key]) : item.foiaReq[key];
+        isVisible.push(request === filter ? 0 : 1);
+      }
+    };
+    return isVisible.reduce((acc, val) => acc + val) === 0;
   }
 
   const uniqueStatuses = new Set();
@@ -26,18 +37,23 @@ const FoiaList = (props) => { const [status, setStatus] = useState();
         <p className="foia-list__filters-heading">Refine results</p>
         <form className="foia-list__filters-form">
           <label htmlFor="foia-list-statuses">Status: </label>
-          <select id="foia-list-statuses" onChange={event => setStatus(event.target.value)}>
+          <select id="foia-list-statuses" onChange={event => setFilters({...filters, status: event.target.value})}>
             <option value="" key="no-status">Select a status</option>
             {filterData.statuses.map(status => (
               <option value={status} key={status}>{status}</option>
             ))}
           </select>
           <label htmlFor="foia-list-prices">Price: </label>
-          <select id="foia-list-prices" onChange={event => setPrice(parseFloat(event.target.value))}>
-            <option value="-0.1" key="no-price">Select a price</option>
+          <select id="foia-list-prices" onChange={event => setFilters({...filters, price: event.target.value})}>
+            <option value="" key="no-price">Select a price</option>
             {filterData.prices.map(price => (
               <option value={price} key={price}>{new Intl.NumberFormat(navigator.language, {style: 'currency', currency: 'USD'}).format(price)}</option>
             ))}
+          </select>
+          <label htmlFor="foia-list-turnaround">Turnaround time:</label>
+          <select id="foia-list-turnaround" onChange={event => setFilters({...filters, datetime_done: event.target.value})}>
+            <option value="">Select a date…</option>
+            <option value="completed">Completed</option>
           </select>
         </form>
       </div>


### PR DESCRIPTION
Abstract the filtering logic so it properly handles multiple filters, as
well as "de-selecting" the filter (choosing "Select a ___").

This paves the way for adding the turn around time filter.

Also add luxon for date parsing.

Another improvement might be to merge the data type with each item, so
that we won't have to hard code exceptions like price into the function.