### PR TITLE
Fix production CORS

### DIFF
--- a/server/src/config/cors.js
+++ b/server/src/config/cors.js
@@ -7,6 +7,10 @@ const corsOptions = {
       allowList = [...allowList, ...localDevOrigins];
     }
 
+    if (process.env.NODE_ENV === "production") {
+      allowList = ['/'];
+    }
+
     if (allowList.indexOf(origin) !== -1) {
       callback(null, true);
     } else {


### PR DESCRIPTION
Add the root path when the `NODE_ENV` environment variable is set to
`production`, as it is on shipyard. This should open up the production
app to query it's own data. The ports should also be taken care of
because of the Docker network layer.

I tested this in-browser and was able to get results. Here's the call I
made:

```js
fetch('/v1/latest')
  .then(response => response.json())
  .then(data => console.log(data))
  .catch(error => console.error(error));
```

This fixes #5