### PR TITLE
Indicate production mode via a different environment variable

### DIFF
--- a/browser/src/App.js
+++ b/browser/src/App.js
@@ -7,9 +7,13 @@ import "astoria-tech-design";
 import "./styles.css";
 
 async function getMuckrockData() {
-  let latest = "/v1/latest";
-  process.env.NODE_ENV === "development" &&
-    (latest = "http://localhost:3000" + latest);
+  // When in production, the API is at the same domain as the frontend
+  let latest;
+  if (process.env.REACT_APP_DEPLOYMENT_MODE === "production") {
+    latest = "/v1/latest";
+  } else {
+    latest = "http://localhost:3000/v1/latest";
+  }
 
   return await fetch(latest)
     .then((response) => (response.ok ? response : Promise.reject(response)))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     build: 'browser/'
     environment:
       CI: 'true'
+      REACT_APP_DEPLOYMENT_MODE: ${REACT_APP_DEPLOYMENT_MODE}
     ports:
       - '3000:3000'
 


### PR DESCRIPTION
So the issue is that create-react-app doesn't allow you to manually set the `NODE_ENV`:

> From https://create-react-app.dev/docs/adding-custom-environment-variables/:
>
> There is also a built-in environment variable called NODE_ENV. You can read it from process.env.NODE_ENV. When you run npm start, it is always equal to 'development', when you run npm test it is always equal to 'test', and when you run npm run build to make a production bundle, it is always equal to 'production'. You cannot override NODE_ENV manually. This prevents developers from accidentally deploying a slow development build to production.

The solution is just to use a different environment variable name.
