### PR TITLE
Add turnaround time bar chart

### DIFF
--- a/browser/src/App.js
+++ b/browser/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useAsync } from "react-async";
 import FoiaList from "./components/FoiaList";
 import { Bar } from "@nivo/bar";
+import { DateTime } from "luxon";
 import "normalize.css";
 import "astoria-tech-design";
 import "./styles.css";
@@ -26,9 +27,45 @@ function App() {
   if (error) return <pre>{JSON.stringify(error, null, 2)}</pre>;
   if (!data) return <p>No data</p>;
 
-  let uniquePrices = new Set();
+  const uniquePrices = new Set();
+  const turnaroundTimes = new Map();
+  turnaroundTimes.set('1–10', 0);
+  turnaroundTimes.set('11–30', 0);
+  turnaroundTimes.set('31–50', 0);
+  turnaroundTimes.set('51–100', 0);
+  turnaroundTimes.set('101–150', 0);
+  turnaroundTimes.set('151+', 0);
 
   data.foiaList.forEach((item) => {
+    if (item.foiaReq.datetime_done) {
+      const start = DateTime.fromISO(item.foiaReq.datetime_submitted);
+      const end = DateTime.fromISO(item.foiaReq.datetime_done);
+      const diff = Math.floor(end.diff(start, 'days').toObject().days);
+      if (diff > 150) {
+        const prev = turnaroundTimes.get('151+');
+        turnaroundTimes.set('151+', prev + 1);
+      }
+      else if (diff > 100) {
+        const prev = turnaroundTimes.get('101–150');
+        turnaroundTimes.set('101–150', prev + 1);
+      }
+      else if (diff > 50) {
+        const prev = turnaroundTimes.get('51–100');
+        turnaroundTimes.set('51–100', prev + 1);
+      }
+      else if (diff > 30) {
+        const prev = turnaroundTimes.get('31–50');
+        turnaroundTimes.set('31–50', prev + 1);
+      }
+      else if (diff > 10) {
+        const prev = turnaroundTimes.get('11–30');
+        turnaroundTimes.set('11–30', prev + 1);
+      }
+      else {
+        const prev = turnaroundTimes.get('1–10');
+        turnaroundTimes.set('1–10', prev + 1);
+      }
+    }
     const price = parseFloat(item.foiaReq.price);
     if (price <= 0) return false;
     uniquePrices.add(price);
@@ -46,8 +83,49 @@ function App() {
       };
     });
 
+  const times = Array.from(turnaroundTimes)
+    .map((item) => {
+      return {
+        value: item[1],
+        id: item[0]
+      }
+    });
+
   return (
     <div className="App">
+      <h2 className="headline__turnaround">Turnaround times</h2>
+      <Bar
+        width={800}
+        height={500}
+        data={times}
+        isInteractive={false}
+        margin={{ top: 0, right: 100, bottom: 50, left: 100 }}
+        padding={0.3}
+        layout="vertical"
+        axisTop={null}
+        axisRight={null}
+        axisBottom={{
+          tickSize: 5,
+          tickPadding: 5,
+          tickRotation: 0,
+          legend: 'Days to complete',
+          legendPosition: 'middle',
+          legendOffset: 32
+        }}
+        axisLeft={{
+          tickSize: 5,
+          tickPadding: 5,
+          tickRotation: 0,
+          legend: 'Amount of requests',
+          legendPosition: 'middle',
+          legendOffset: -40
+        }}
+        labelSkipWidth={12}
+        labelSkipHeight={12}
+        labelTextColor={{ from: 'color', modifiers: [ [ 'darker', 1.6 ] ] }}
+        borderColor={{ from: 'color', modifiers: [ [ 'darker', 1.6 ] ] }}
+        colors={{ scheme: "nivo" }}
+      />
       <h2 className="headline__costs">Range of 50a request costs</h2>
       <Bar
         width={800}


### PR DESCRIPTION
First pass at a chart showing turnaround times.

Operate on completed requests, showing how long it took to complete.
Since there are more than a hundred unique days-to-complete, putting
them all in a chart is unreadable, at least with my struggling
understanding of nivo.

To compensate, and to stop fighting the library, I manually grouped the
items coarsely.

## Screenshot
<img width="780" alt="Screen Shot 2021-01-09 at 9 18 24 PM" src="https://user-images.githubusercontent.com/637174/104112699-4503af80-52c0-11eb-8b27-ff1e6ec47e78.png">
