### PR TITLE
Graphs go full width

### DIFF
--- a/browser/src/App.js
+++ b/browser/src/App.js
@@ -124,7 +124,7 @@ function App() {
         <p>Visualizing the process of requesting Freedom of Information Law Requests from New York State Police Departments</p>
         <h2>Explore the data</h2>
         <h3>Status of Requests</h3>
-        <div className="graph">
+        <div className="graph graph--tree-map">
           <ResponsiveTreeMap
             data={statusGraphData()}
             identity="name"
@@ -140,7 +140,7 @@ function App() {
         <p>In response to the Freedom of Information Law Requests, New York State police departments have claimed to have no records (“no documents”) of officer misconduct from the past 50 years.</p>
         <p>The done status may not mean that the request was successful, Muckrock is restarting some requests from the beginning after having previous requests rejected. The appealing process means that the initial request was rejected and that they are rewriting their argument and a copy of the letter must go to the Committe on Open Government. A lawsuit status indicates that the process has escalated to the courtroom.</p>
         <h3>Timeline of the Request Process</h3>
-        <div className="graph">
+        <div className="graph graph--bar">
           <ResponsiveBar
             data={times}
             isInteractive={false}
@@ -174,7 +174,7 @@ function App() {
         </div>
         <p>Agencies have five days to confirm a FOIL request, but are not held to any timeline for how long it takes them to complete the request.</p>
         <h3>Fees Charged by agency</h3>
-        <div className="graph">
+        <div className="graph graph--bar">
           <ResponsiveBar
             isInteractive={false}
             margin={{ top: 0, right: 100, bottom: 50, left: 100 }}

--- a/browser/src/styles.css
+++ b/browser/src/styles.css
@@ -5,8 +5,16 @@
   --ad-primary-color: #98bb35;
 }
 
-.graph {
-  height: 500px;
+@media screen and (min-width: 800px) {
+  main {
+    max-width: none;
+    display: grid;
+    grid-template-columns: 1fr 10ch 65ch 10ch 1fr;
+  }
+}
+
+main > * {
+  grid-column: 3 / span 1;
 }
 
 header {
@@ -17,6 +25,16 @@ header h1 {
   display: flex;
   margin-left: auto;
   margin-right: auto;
+}
+
+.graph {
+  height: 90vh;
+  max-width: 100vw;
+  grid-column: 1 / -1;
+}
+
+.graph--tree-map {
+  grid-column: 2 / span 3;
 }
 
 .foia-list__item-table {


### PR DESCRIPTION
Change layout so the graphs blow out to full width when the screen is
large enough to support this, while keeping the text content and a
comfortable, narrow, and centered width.

Hoping this will showcase graphs nicely while allowing text to stay
readable.

I had this idea while looking into form styling, which I think could benefit from some version of this approach as well, but wanted to submit the idea to the team first before plowing ahead.

I put everyone on the PR as a reviewer for visibility, but I think it can be merged after 2 approvals (that's a general philosophy of mine, feel free to disagree).

## Screenshots

<details>
<summary>Large screens</summary>
<img src="https://user-images.githubusercontent.com/637174/108756019-fdef1800-7515-11eb-88bd-11f099b8a10f.png">
</details>

<details>
<summary>Small screens</summary>
<img src="https://user-images.githubusercontent.com/637174/108756033-00517200-7516-11eb-850a-80d78e8a279a.png">
</details>