### PR TITLE
Enhance filter drop down styles

### DIFF
--- a/browser/src/components/FoiaList.js
+++ b/browser/src/components/FoiaList.js
@@ -26,7 +26,6 @@ const FoiaList = (props) => {
     return isVisible.reduce((acc, val) => acc + val) === 0;
   }
 
-  const uniqueDone = new Set();
   const uniqueStatuses = new Set();
   const uniquePrices = new Set();
   props.data.foiaList.forEach(item => {
@@ -60,29 +59,34 @@ const FoiaList = (props) => {
     <div className="foia-list">
       <h2 className="foia-list__headline">FOIA list</h2>
       <div className="foia-list__filters">
-        <p className="foia-list__filters-heading">Refine results</p>
         <form className="foia-list__filters-form">
-          <label htmlFor="foia-list-statuses">Status: </label>
-          <select id="foia-list-statuses" onChange={event => setFilters({...filters, status: event.target.value})}>
-            <option value="" key="no-status">Select a status</option>
-            {filterData.statuses.map(status => (
-              <option value={status} key={status}>{status}</option>
-            ))}
-          </select>
-          <label htmlFor="foia-list-prices">Price: </label>
-          <select id="foia-list-prices" onChange={event => setFilters({...filters, price: event.target.value})}>
-            <option value="" key="no-price">Select a price</option>
-            {filterData.prices.map(price => (
-              <option value={price} key={price}>{new Intl.NumberFormat(navigator.language, {style: "currency", currency: "USD"}).format(price)}</option>
-            ))}
-          </select>
-          <label htmlFor="foia-list-turnaround">Turnaround time:</label>
-          <select id="foia-list-turnaround" onChange={event => setFilters({...filters, turnaroundTime: event.target.value})}>
-            <option value="" key="no-date">Select a date…</option>
-            {filterData.turnaroundTimes.map(time => (
-              <option value={time.value} key={time.label}>{time.label}</option>
-            ))}
-          </select>
+          <label htmlFor="foia-list-statuses">
+            Status:
+            <select id="foia-list-statuses" onChange={event => setFilters({...filters, status: event.target.value})}>
+              <option value="" key="no-status">Select a status</option>
+              {filterData.statuses.map(status => (
+                <option value={status} key={status}>{status}</option>
+              ))}
+            </select>
+          </label>
+          <label htmlFor="foia-list-prices">
+            Price:
+            <select id="foia-list-prices" onChange={event => setFilters({...filters, price: event.target.value})}>
+              <option value="" key="no-price">Select a price</option>
+              {filterData.prices.map(price => (
+                <option value={price} key={price}>{new Intl.NumberFormat(navigator.language, {style: "currency", currency: "USD"}).format(price)}</option>
+              ))}
+            </select>
+          </label>
+          <label htmlFor="foia-list-turnaround">
+            Turnaround time:
+            <select id="foia-list-turnaround" onChange={event => setFilters({...filters, turnaroundTime: event.target.value})}>
+              <option value="" key="no-date">Select a date…</option>
+              {filterData.turnaroundTimes.map(time => (
+                <option value={time.value} key={time.label}>{time.label}</option>
+              ))}
+            </select>
+          </label>
         </form>
       </div>
       <div className="foia-list__results">

--- a/browser/src/styles.css
+++ b/browser/src/styles.css
@@ -37,6 +37,24 @@ header h1 {
   grid-column: 2 / span 3;
 }
 
+.foia-list__headline {
+  margin-bottom: 0.25em;
+}
+
+.foia-list__filters-form {
+  display: flex;
+  justify-content: space-between;
+  flex-flow: row wrap;
+}
+
+.foia-list label {
+  display: flex;
+  margin-top: 1em;
+  font-size: 0.85em;
+  font-weight: 500;
+  flex-flow: column nowrap;
+}
+
 .foia-list__item-table {
   width: 100%;
   text-align: left;


### PR DESCRIPTION
Lay out the filter drop downs more elegantly so they stack with even
spacing at small widths, and are arranged horizontally at larger widths.

Also remove the Refine results subtitle and remove an unused variable.

Fixes #24

## Screenshots

<details>
<summary>Small screens</summary>
<img width="323" alt="Screen Shot 2021-02-27 at 5 22 26 PM" src="https://user-images.githubusercontent.com/637174/109402106-1a79be80-7921-11eb-8630-70d895a708bd.png">
</details>

<details>
<summary>Large screens</summary>
<img width="867" alt="Screen Shot 2021-02-27 at 5 22 07 PM" src="https://user-images.githubusercontent.com/637174/109402113-2c5b6180-7921-11eb-8ead-32edce03d74d.png">
</details>