### PR TITLE
Add funnel chart dependency

### DIFF
--- a/browser/package-lock.json
+++ b/browser/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@nivo/bar": "^0.67.0",
         "@nivo/core": "^0.67.0",
+        "@nivo/funnel": "^0.67.0",
         "@nivo/treemap": "^0.67.0",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.5.0",
@@ -1846,6 +1847,24 @@
       },
       "peerDependencies": {
         "@nivo/tooltip": "0.67.0",
+        "prop-types": ">= 15.5.10 < 16.0.0",
+        "react": ">= 16.8.4 < 18.0.0"
+      }
+    },
+    "node_modules/@nivo/funnel": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@nivo/funnel/-/funnel-0.67.0.tgz",
+      "integrity": "sha512-FR4FOBuz7pNNoQ6BUhYIJe2/2KKBOS63NFFh4lQGzjBSbnw7XeR7pXGFT5w8tvzySLZcPjxq5qPt9iGQ1DWgIg==",
+      "dependencies": {
+        "d3-scale": "^3.0.0",
+        "d3-shape": "^1.3.5",
+        "react-spring": "9.0.0-rc.3"
+      },
+      "peerDependencies": {
+        "@nivo/annotations": "0.63.1",
+        "@nivo/colors": "0.63.0",
+        "@nivo/core": "0.67.0",
+        "@nivo/tooltip": "0.63.0",
         "prop-types": ">= 15.5.10 < 16.0.0",
         "react": ">= 16.8.4 < 18.0.0"
       }
@@ -19404,6 +19423,16 @@
         "react-spring": "9.0.0-rc.3",
         "recompose": "^0.30.0",
         "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "@nivo/funnel": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@nivo/funnel/-/funnel-0.67.0.tgz",
+      "integrity": "sha512-FR4FOBuz7pNNoQ6BUhYIJe2/2KKBOS63NFFh4lQGzjBSbnw7XeR7pXGFT5w8tvzySLZcPjxq5qPt9iGQ1DWgIg==",
+      "requires": {
+        "d3-scale": "^3.0.0",
+        "d3-shape": "^1.3.5",
+        "react-spring": "9.0.0-rc.3"
       }
     },
     "@nivo/legends": {

--- a/browser/package.json
+++ b/browser/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@nivo/bar": "^0.67.0",
     "@nivo/core": "^0.67.0",
+    "@nivo/funnel": "^0.67.0",
     "@nivo/treemap": "^0.67.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",


### PR DESCRIPTION
The funnel chart dependency tree is out of sync with other nivo
dependencies, throwing an error when trying to install it. However, it
seems like the upstream version numbers just weren't bumped, and the
package works fine in my tests. I force installed it and was able to get
a dummy funnel chart in the app.

Here's the code I used to test the funnel after the package install (can be downloaded as a patch and applied).

```diff
diff --git a/browser/src/App.js b/browser/src/App.js
index 957841b..1e1dc48 100644
--- a/browser/src/App.js
+++ b/browser/src/App.js
@@ -3,6 +3,7 @@ import { useAsync } from "react-async";
 import FoiaList from "./components/FoiaList";
 import { ResponsiveBar } from "@nivo/bar";
 import { ResponsiveTreeMap } from "@nivo/treemap";
+import { ResponsiveFunnel } from "@nivo/funnel";
 import { DateTime } from "luxon";
 import HamburgerMenu from "react-hamburger-menu";
 import Drawer from "./components/Toolbar/Drawer/Drawer";
@@ -100,6 +101,34 @@ function App() {
     }
   });
 
+  const funnelData = [
+    {
+      "id": "step_sent",
+      "value": 75411,
+      "label": "Sent"
+    },
+    {
+      "id": "step_viewed",
+      "value": 61035,
+      "label": "Viewed"
+    },
+    {
+      "id": "step_clicked",
+      "value": 48089,
+      "label": "Clicked"
+    },
+    {
+      "id": "step_add_to_card",
+      "value": 45499,
+      "label": "Add To Card"
+    },
+    {
+      "id": "step_purchased",
+      "value": 32888,
+      "label": "Purchased"
+    }
+  ]
+
   const statusGraphData = function statusGraphData() {
     // Sweet math here. Return result when done.
     return tmpdata;
@@ -172,6 +201,23 @@ function App() {
           lawsuit status indicates that the process has escalated to the
           courtroom.
         </p>
+        <div style={{ height: '600px' }}>
+        <ResponsiveFunnel
+            data={funnelData}
+            margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+            valueFormat=">-.4s"
+            colors={{ scheme: 'spectral' }}
+            borderWidth={20}
+            labelColor={{ from: 'color', modifiers: [ [ 'darker', 3 ] ] }}
+            beforeSeparatorLength={100}
+            beforeSeparatorOffset={20}
+            afterSeparatorLength={100}
+            afterSeparatorOffset={20}
+            currentPartSizeExtension={10}
+            currentBorderWidth={40}
+            motionConfig="wobbly"
+        />
+        </div>
         <h3>Timeline of the Request Process</h3>
         <div className="graph graph--bar">
           <ResponsiveBar
```

re #69